### PR TITLE
Avoid potential NullPointerException in LootingLevelEvent subscriber

### DIFF
--- a/src/main/java/uniquee/handler/EntityEvents.java
+++ b/src/main/java/uniquee/handler/EntityEvents.java
@@ -915,7 +915,7 @@ public class EntityEvents
 	@SubscribeEvent
 	public void onLootingLevel(LootingLevelEvent event)
 	{
-		Entity entity = event.getDamageSource().getTrueSource();
+		Entity entity = event.getDamageSource() == null ? null : event.getDamageSource().getTrueSource();
 		if(entity instanceof LivingEntity && event.getEntityLiving() instanceof AbstractSkeletonEntity)
 		{
 			int level = MiscUtil.getEnchantmentLevel(UniqueEnchantments.BONE_CRUSH, ((LivingEntity)entity).getHeldItemMainhand());


### PR DESCRIPTION
Due to global loot modifiers, there is no guarantee that that a damage
source exists, and thus getDamageSource() has a chance to return null.
This commit adds a check to prevent a NullPointerException in such
cases. You can read more about the details in [this Forge github
issue](https://github.com/MinecraftForge/MinecraftForge/issues/7714).